### PR TITLE
Python patch

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure("2") do |config|
   # documentation for more information about their specific syntax and use.
   config.vm.provision "file", source: "./install.sh", destination: "/Users/vagrant/install.sh"
   config.vm.provision "file", source: "./.secrets.sh", destination: "/Users/vagrant/.secrets.sh"
-  # config.vm.provision "file", source: "./patches/python.cmake.patch", destination: "/Users/vagrant/patches/python.cmake.patch"
+  config.vm.provision "file", source: "./patches/python.cmake.patch", destination: "/Users/vagrant/patches/python.cmake.patch"
   # config.vm.provision "file", source: "./patches/muongun-histogram.cxx.patch", destination: "/Users/vagrant/patches/muongun-histogram.cxx.patch"
   # config.vm.provision "file", source: "./patches/boost.cmake.patch", destination: "/Users/vagrant/patches/boost.cmake.patch"
   config.vm.provision "shell", privileged: false, inline: <<-SHELL

--- a/install.sh
+++ b/install.sh
@@ -128,17 +128,15 @@ if [[ ! -z $EXCLUDE_PROJECTS ]]; then
   done
 fi
 
-if [[ "$PLATFORM" = "macOS-10.14" ]]; then
-  # Patch cmake file to find pymalloc version of python installed by homebrew
-  # https://github.com/fiedl/hole-ice-install/issues/1
-  #
-  # This is still an issue in icecube-combo-V00-00-00-RC2, but is fixed
-  # in `trunk` and `stable` already.
-  # https://icecube-spno.slack.com/archives/C02KQL9KN/p1572367112229900
-  #
-  if [[ $RELEASE = "V00-00-00-RC2" ]]; then
-    patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
-  fi
+# Patch cmake file to find pymalloc version of python.
+# https://github.com/fiedl/hole-ice-install/issues/1
+#
+# This is still an issue in icecube-combo-V00-00-00-RC2, but is fixed
+# in `trunk` and `stable` already.
+# https://icecube-spno.slack.com/archives/C02KQL9KN/p1572367112229900
+#
+if [[ $RELEASE = "V00-00-00-RC2" ]]; then
+  patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
 fi
 
 #if [[ $RELEASE = "V06-01-01" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -128,11 +128,14 @@ if [[ ! -z $EXCLUDE_PROJECTS ]]; then
   done
 fi
 
+if [[ "$PLATFORM" = "macOS-10.14" ]]; then
+  # Patch cmake file to find pymalloc version of python installed by homebrew
+  # https://github.com/fiedl/hole-ice-install/issues/1
+  patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
+fi
+
 #if [[ $RELEASE = "V06-01-01" ]]; then
 #
-#  # Patch cmake file to find pymalloc version of python installed by homebrew
-#  # https://github.com/fiedl/hole-ice-install/issues/1
-#  patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
 #
 #  # Patch muongun pybindings to add missing static cast
 #  # https://github.com/fiedl/hole-ice-install/issues/2

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,14 @@ fi
 if [[ "$PLATFORM" = "macOS-10.14" ]]; then
   # Patch cmake file to find pymalloc version of python installed by homebrew
   # https://github.com/fiedl/hole-ice-install/issues/1
-  patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
+  #
+  # This is still an issue in icecube-combo-V00-00-00-RC2, but is fixed
+  # in `trunk` and `stable` already.
+  # https://icecube-spno.slack.com/archives/C02KQL9KN/p1572367112229900
+  #
+  if [[ $RELEASE = "V00-00-00-RC2" ]]; then
+    patch --force $ICECUBE_COMBO_ROOT/src/cmake/tools/python.cmake < ./patches/python.cmake.patch
+  fi
 fi
 
 #if [[ $RELEASE = "V06-01-01" ]]; then


### PR DESCRIPTION
https://icecube-spno.slack.com/archives/C02KQL9KN/p1572359919221500

> I’m trying to install combo on macOS. During make, I’m getting:
>
> Undefined symbols for architecture x86_64: “_PyInt_FromLong”, referenced from boost::python::converter::arg_to_python<unsigned int>::arg_to_python(unsigned int const&) in PythonFunction.cxx.o
>
> I’ve also setup a ci job to reproduce it. Same issue there. For the whole output, see: https://github.com/fiedl/icecube-combo-install/runs/278175768#step:3:19797
> I’ve seen this issue before in simulation trunk, but **not** in simulation V06-01-01 (https://github.com/fiedl/icecube-simulation-install/issues/2)

It has been suggested that this might result from the wrong python headers being used.

https://icecube-spno.slack.com/archives/C02KQL9KN/p1572362707224800

> that is very clearly an issue with using some bad combination of python 2 and 3, where one of headers, library, or executable is a different version from the others
> I would guess headers

Indeed, the `includes` line indicating the location of the headers does not match the others.

https://github.com/fiedl/icecube-combo-install/commit/55f5b13cde608ba926536bf372fbee2cedf3ad08/checks?check_suite_id=286486319#step:3:19105

```
-- python 
-- +  version: 3.7.4
-- + base dir: /usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7
-- +   binary: /usr/local/opt/python/libexec/bin/python
-- + includes: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/System/Library/Frameworks/Python.framework/Headers
-- +     libs: /usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib
-- +    numpy: /usr/local/lib/python3.7/site-packages/numpy/core/include
-- +    scipy: FOUND
```

https://icecube-spno.slack.com/archives/C02KQL9KN/p1572367112229900

> I have found the issue: On macOS, the python version installed by `brew install python` is `python3.7m`. The `m` refers to the version compiled with `--with-pymalloc` rather than regular `malloc`. Unfortunately, the cmake configuration `python.cmake` does not find the python include dir for this version. That’s why the headers do not match.
>
> I have written a patch for `src/cmake/tools/python.cmake` that fixes the issue: https://github.com/fiedl/hole-ice-install/commit/a55f73f66ee919c75a180083807edf9640c6858a#diff-70c9512aca4457f3cc27b590ff9e9f6b
>
> But, I’ve also just seen that this is already fixed in `trunk` and `stable`.

This pull request does provide a patch for the current release `V00-00-00-RC2`. This fix is already included in `stable` and `trunk`. Also, this fix is no longer needed as of python 3.8:

https://icecube-spno.slack.com/archives/C02KQL9KN/p1572367508230400

> the better news: starting with python 3.8, they got rid of the `m` suffix

This fix has originally been provided in https://github.com/fiedl/hole-ice-install/issues/1, 
https://github.com/fiedl/hole-ice-install/commit/a55f73f66ee919c75a180083807edf9640c6858a#diff-70c9512aca4457f3cc27b590ff9e9f6b.