### PR TITLE
updating boost to current version 1.71

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -56,10 +56,10 @@ fi
 # Install boost with python bindings
 if [[ "$PLATFORM" = "macOS-10.14" ]]; then
   brew info boost
-  brew install fiedl/homebrew-icecube/boost@1.69
+  brew install boost
   brew info boost-python
   brew info boost-python3
-  brew install fiedl/homebrew-icecube/boost-python3@1.69
+  brew install boost-python3
 elif [[ "$PLATFORM" = "ubuntu-18.04" ]]; then
   sudo apt-get install -y libboost-all-dev libboost-python1.65.1
 fi


### PR DESCRIPTION
https://icecube-spno.slack.com/archives/C02KQL9KN/p1572359919221500

> I’m trying to install combo on macOS. During make, I’m getting:
>
> Undefined symbols for architecture x86_64: “_PyInt_FromLong”, referenced from boost::python::converter::arg_to_python<unsigned int>::arg_to_python(unsigned int const&) in PythonFunction.cxx.o
>
> I’ve also setup a ci job to reproduce it. Same issue there. For the whole output, see: https://github.com/fiedl/icecube-combo-install/runs/278175768#step:3:19797
> I’ve seen this issue before in simulation trunk, but **not** in simulation V06-01-01 (https://github.com/fiedl/icecube-simulation-install/issues/2)

It has been suggested (https://icecube-spno.slack.com/archives/C02KQL9KN/p1572362032224700) to update boost.

> I had issues with boost 1.69, can you try 1.70 or 1.71?

This pull request updates the boost version from 1.69 to the current version 1.71.

The current version of icecube-combo does not require boost 1.69 anymore. This makes https://github.com/IceCube-SPNO/homebrew-icecube/pull/35 obsolete as icecube-simulation is discontinued (https://github.com/fiedl/icecube-simulation-install/issues/9).