### PR TITLE
Run `make` already inside an `env-shell.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -160,8 +160,7 @@ fi
 mkdir -p $ICECUBE_COMBO_ROOT/debug_build
 cd $ICECUBE_COMBO_ROOT/debug_build
 cmake -D CMAKE_BUILD_TYPE=Debug -D SYSTEM_PACKAGES=true -D CMAKE_BUILD_TYPE:STRING=Debug ../src
-source ./env-shell.sh
-make -j 6
+./env-shell.sh make -j 6
 
 # # Build the release
 # mkdir -p $ICECUBE_COMBO_ROOT/build

--- a/install.sh
+++ b/install.sh
@@ -160,7 +160,7 @@ fi
 mkdir -p $ICECUBE_COMBO_ROOT/debug_build
 cd $ICECUBE_COMBO_ROOT/debug_build
 cmake -D CMAKE_BUILD_TYPE=Debug -D SYSTEM_PACKAGES=true -D CMAKE_BUILD_TYPE:STRING=Debug ../src
-# source ./env-shell.sh  # <--- is this needed here?
+source ./env-shell.sh
 make -j 6
 
 # # Build the release


### PR DESCRIPTION
This pull request makes the `make` command, which builds the icecube software, run within an `env-shell.sh` environment.

I'm not sure whether this is needed. 

Locally, I'm successfully `make`ing without an env-shell. But I'm setting some environment variables by hand in my `~/.zshenv`:

```bash
# ~/.zshenv
export ICECUBE_ROOT="$HOME/icecube/software"
export CUDA_CACHE_DISABLE=1

export RELEASE=V00-00-00-RC2
export ICECUBE_COMBO_ROOT=$ICECUBE_ROOT/icecube-combo-$RELEASE
export ICECUBE_COMBO=$ICECUBE_COMBO_ROOT/debug_build

export I3_PORTS=$ICECUBE_ROOT/ports
export SVN="..."

export I3_SRC=$ICECUBE_COMBO_ROOT/src
export I3_BUILD=$ICECUBE_COMBO
export I3_TESTDATA=$ICECUBE_COMBO_ROOT/ports/test-data
```

But it can't hurt to use the env-shell. This should make the `make` use the expected python versions etc. specified during ` cmake`.